### PR TITLE
Multiple node creation

### DIFF
--- a/create/node.go
+++ b/create/node.go
@@ -17,7 +17,7 @@ type baseNodeTerraformConfig struct {
 	Source string `json:"source"`
 
 	Hostname  string `json:"hostname"`
-	NodeCount int
+	NodeCount int    `json:"-"`
 
 	RancherAPIURL        string                  `json:"rancher_api_url"`
 	RancherAccessKey     string                  `json:"rancher_access_key"`

--- a/create/node.go
+++ b/create/node.go
@@ -3,6 +3,7 @@ package create
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/joyent/triton-kubernetes/backend"
@@ -15,7 +16,8 @@ import (
 type baseNodeTerraformConfig struct {
 	Source string `json:"source"`
 
-	Hostname string `json:"hostname"`
+	Hostname  string `json:"hostname"`
+	NodeCount int64
 
 	RancherAPIURL        string                  `json:"rancher_api_url"`
 	RancherAccessKey     string                  `json:"rancher_access_key"`
@@ -207,7 +209,36 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 		return baseNodeTerraformConfig{}, fmt.Errorf("Invalid rancher_host_label '%s', must be 'compute', 'etcd' or 'orchestration'", selectedHostLabel)
 	}
 
-	// TODO: Allow user to specify number of nodes to be created.
+	// Allow user to specify number of nodes to be created.
+	var countInput string
+	if viper.IsSet("node_count") {
+		countInput = viper.GetString("node_count")
+	} else {
+		prompt := promptui.Prompt{
+			Label: "Number of nodes to create",
+			Validate: func(input string) error {
+				_, err := strconv.ParseInt(input, 10, 64)
+				if err != nil {
+					return errors.New("Invalid number")
+				}
+				return nil
+			},
+		}
+
+		result, err := prompt.Run()
+		if err != nil {
+			return baseNodeTerraformConfig{}, err
+		}
+
+		countInput = result
+	}
+
+	// Verifying node count
+	nodeCount, err := strconv.ParseInt(countInput, 10, 64)
+	if err != nil {
+		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be a valid number. Found '%s'.", countInput)
+	}
+	cfg.NodeCount = nodeCount
 
 	// hostname
 	if viper.IsSet("hostname") {

--- a/create/node.go
+++ b/create/node.go
@@ -261,3 +261,51 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 
 	return cfg, nil
 }
+
+// Returns the hostnames that should be used when adding new nodes. Prevents naming collisions.
+func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []string {
+	if nodesToAdd < 1 {
+		return []string{}
+	}
+
+	// If there's only one node to add, and the name doesn't exist
+	// just return the node name itself.
+	if nodesToAdd == 1 {
+		nodeNameUsed := false
+		for _, existingName := range existingNames {
+			if existingName == nodeName {
+				nodeNameUsed = true
+				break
+			}
+		}
+		if !nodeNameUsed {
+			return []string{nodeName}
+		}
+	}
+
+	// Find the number at which the series of hostnames should start.
+	startNum := 1
+	targetPrefix := nodeName + "-"
+	for _, existingName := range existingNames {
+		if !strings.HasPrefix(existingName, targetPrefix) {
+			continue
+		}
+
+		suffix := existingName[len(targetPrefix):]
+		numSuffix, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+		if numSuffix >= startNum {
+			startNum = numSuffix + 1
+		}
+	}
+
+	// Build the list of hostnames
+	result := []string{}
+	for i := 0; i < nodesToAdd; i++ {
+		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
+	}
+
+	return result
+}

--- a/create/node.go
+++ b/create/node.go
@@ -17,7 +17,7 @@ type baseNodeTerraformConfig struct {
 	Source string `json:"source"`
 
 	Hostname  string `json:"hostname"`
-	NodeCount int64
+	NodeCount int
 
 	RancherAPIURL        string                  `json:"rancher_api_url"`
 	RancherAccessKey     string                  `json:"rancher_access_key"`
@@ -234,7 +234,7 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 	}
 
 	// Verifying node count
-	nodeCount, err := strconv.ParseInt(countInput, 10, 64)
+	nodeCount, err := strconv.Atoi(countInput)
 	if err != nil {
 		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be a valid number. Found '%s'.", countInput)
 	}

--- a/create/node.go
+++ b/create/node.go
@@ -275,21 +275,6 @@ func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []
 		return []string{}
 	}
 
-	// If there's only one node to add, and the name doesn't exist
-	// just return the node name itself.
-	if nodesToAdd == 1 {
-		nodeNameUsed := false
-		for _, existingName := range existingNames {
-			if existingName == nodeName {
-				nodeNameUsed = true
-				break
-			}
-		}
-		if !nodeNameUsed {
-			return []string{nodeName}
-		}
-	}
-
 	// Find the number at which the series of hostnames should start.
 	startNum := 1
 	targetPrefix := nodeName + "-"

--- a/create/node.go
+++ b/create/node.go
@@ -217,9 +217,12 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 		prompt := promptui.Prompt{
 			Label: "Number of nodes to create",
 			Validate: func(input string) error {
-				_, err := strconv.ParseInt(input, 10, 64)
+				num, err := strconv.ParseInt(input, 10, 64)
 				if err != nil {
 					return errors.New("Invalid number")
+				}
+				if num <= 0 {
+					return errors.New("Number must be greater than 0")
 				}
 				return nil
 			},
@@ -238,6 +241,10 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 	if err != nil {
 		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be a valid number. Found '%s'.", countInput)
 	}
+	if nodeCount <= 0 {
+		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be greater than 0. Found '%d'.", nodeCount)
+	}
+
 	cfg.NodeCount = nodeCount
 
 	// hostname

--- a/create/node_aws.go
+++ b/create/node_aws.go
@@ -167,7 +167,7 @@ func newAWSNode(selectedClusterManager, selectedCluster string, remoteBackend ba
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(awsNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_azure.go
+++ b/create/node_azure.go
@@ -233,7 +233,7 @@ func newAzureNode(selectedClusterManager, selectedCluster string, remoteBackend 
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(azureNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_azure.go
+++ b/create/node_azure.go
@@ -218,10 +218,27 @@ func newAzureNode(selectedClusterManager, selectedCluster string, remoteBackend 
 		cfg.AzurePublicKeyPath = expandedPublicKeyPath
 	}
 
-	// Add new node to terraform config
-	err = state.Add(fmt.Sprintf(azureNodeKeyFormat, cfg.Hostname), &cfg)
+	// Get existing node names
+	nodes, err := state.Nodes(selectedCluster)
 	if err != nil {
 		return err
+	}
+	existingNames := []string{}
+	for nodeName := range nodes {
+		existingNames = append(existingNames, nodeName)
+	}
+
+	// Determine what the hostnames should be for the new node(s)
+	newHostnames := getNewHostnames(existingNames, cfg.Hostname, cfg.NodeCount)
+
+	// Add new node to terraform config with the new hostnames
+	for _, newHostname := range newHostnames {
+		cfgCopy := *(&cfg)
+		cfgCopy.Hostname = newHostname
+		err = state.Add(fmt.Sprintf(azureNodeKeyFormat, newHostname), cfgCopy)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create a temporary directory

--- a/create/node_gcp.go
+++ b/create/node_gcp.go
@@ -231,7 +231,7 @@ func newGCPNode(selectedClusterManager, selectedCluster string, remoteBackend ba
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(gcpNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_test.go
+++ b/create/node_test.go
@@ -1,0 +1,48 @@
+package create
+
+import (
+	"fmt"
+	"testing"
+)
+
+var getNewHostnamesTestCases = []struct {
+	ExistingNames []string
+	NodeName      string
+	NodesToAdd    int
+	Expected      []string
+}{
+	// node count <= 0
+	{[]string{"test-1", "test-2"}, "test", 0, []string{}},
+	{[]string{"test-1", "test-2"}, "test", -10, []string{}},
+	// node count == 1
+	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar"}},
+	{[]string{"test"}, "test", 1, []string{"test-1"}},
+	// node count > 1
+	{[]string{"foo", "bar"}, "test", 3, []string{"test-1", "test-2", "test-3"}},
+	{[]string{"test"}, "test", 3, []string{"test-1", "test-2", "test-3"}},
+	{[]string{"test-1", "test-2", "bar-3", "bar-4"}, "test", 3, []string{"test-3", "test-4", "test-5"}},
+}
+
+func TestGetNewHostnames(t *testing.T) {
+	for _, tc := range getNewHostnamesTestCases {
+		output := getNewHostnames(tc.ExistingNames, tc.NodeName, tc.NodesToAdd)
+		if !isEqual(tc.Expected, output) {
+			msg := fmt.Sprintf("\nInput:    (%q, %q, %d)\n", tc.ExistingNames, tc.NodeName, tc.NodesToAdd)
+			msg += fmt.Sprintf("Output:   %q\n", output)
+			msg += fmt.Sprintf("Expected: %q\n", tc.Expected)
+			t.Error(msg)
+		}
+	}
+}
+
+func isEqual(expected, actual []string) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for index, expectedItem := range expected {
+		if actual[index] != expectedItem {
+			return false
+		}
+	}
+	return true
+}

--- a/create/node_test.go
+++ b/create/node_test.go
@@ -15,7 +15,7 @@ var getNewHostnamesTestCases = []struct {
 	{[]string{"test-1", "test-2"}, "test", 0, []string{}},
 	{[]string{"test-1", "test-2"}, "test", -10, []string{}},
 	// node count == 1
-	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar"}},
+	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar-1"}},
 	{[]string{"test"}, "test", 1, []string{"test-1"}},
 	// node count > 1
 	{[]string{"foo", "bar"}, "test", 3, []string{"test-1", "test-2", "test-3"}},

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -245,7 +245,9 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), &cfg)
+		cfgCopy := *(&cfg)
+		cfgCopy.Hostname = newHostname
+		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {
 			return err
 		}

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -244,7 +244,7 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/joyent/triton-kubernetes/backend"
@@ -229,10 +230,25 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 		cfg.TritonMachinePackage = kvmPackages[i].Name
 	}
 
-	// Add new node to terraform config
-	err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, cfg.Hostname), &cfg)
+	// Get existing node names
+	nodes, err := state.Nodes(selectedCluster)
 	if err != nil {
 		return err
+	}
+	existingNames := []string{}
+	for nodeName := range nodes {
+		existingNames = append(existingNames, nodeName)
+	}
+
+	// Determine what the hostnames should be for the new node(s)
+	newHostnames := getNewHostnames(existingNames, cfg.Hostname, cfg.NodeCount)
+
+	// Add new node to terraform config with the new hostnames
+	for _, newHostname := range newHostnames {
+		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), &cfg)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create a temporary directory
@@ -273,4 +289,52 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 	}
 
 	return nil
+}
+
+// Returns the hostnames that should be used when adding new nodes. Prevents naming collisions.
+func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []string {
+	if nodesToAdd < 1 {
+		return []string{}
+	}
+
+	// If there's only one node to add, and the name doesn't exist
+	// just return the node name itself.
+	if nodesToAdd == 1 {
+		nodeNameUsed := false
+		for _, existingName := range existingNames {
+			if existingName == nodeName {
+				nodeNameUsed = true
+				break
+			}
+		}
+		if !nodeNameUsed {
+			return []string{nodeName}
+		}
+	}
+
+	// Find the number at which the series of hostnames should start.
+	startNum := 1
+	targetPrefix := nodeName + "-"
+	for _, existingName := range existingNames {
+		if !strings.HasPrefix(existingName, targetPrefix) {
+			continue
+		}
+
+		suffix := existingName[len(targetPrefix):]
+		numSuffix, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+		if numSuffix >= startNum {
+			startNum = numSuffix + 1
+		}
+	}
+
+	// Build the list of hostnames
+	result := []string{}
+	for i := 0; i < nodesToAdd; i++ {
+		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
+	}
+
+	return result
 }

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/joyent/triton-kubernetes/backend"
@@ -291,52 +290,4 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 	}
 
 	return nil
-}
-
-// Returns the hostnames that should be used when adding new nodes. Prevents naming collisions.
-func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []string {
-	if nodesToAdd < 1 {
-		return []string{}
-	}
-
-	// If there's only one node to add, and the name doesn't exist
-	// just return the node name itself.
-	if nodesToAdd == 1 {
-		nodeNameUsed := false
-		for _, existingName := range existingNames {
-			if existingName == nodeName {
-				nodeNameUsed = true
-				break
-			}
-		}
-		if !nodeNameUsed {
-			return []string{nodeName}
-		}
-	}
-
-	// Find the number at which the series of hostnames should start.
-	startNum := 1
-	targetPrefix := nodeName + "-"
-	for _, existingName := range existingNames {
-		if !strings.HasPrefix(existingName, targetPrefix) {
-			continue
-		}
-
-		suffix := existingName[len(targetPrefix):]
-		numSuffix, err := strconv.Atoi(suffix)
-		if err != nil {
-			continue
-		}
-		if numSuffix >= startNum {
-			startNum = numSuffix + 1
-		}
-	}
-
-	// Build the list of hostnames
-	result := []string{}
-	for i := 0; i < nodesToAdd; i++ {
-		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
-	}
-
-	return result
 }


### PR DESCRIPTION
This adds the ability to create multiple nodes of the same configuration in one command. The hostnames of the new nodes will consist of the user-specified hostname joined with an increasing number (e.g. hostname-1, hostname-2, hostname-3). The hostnames are generated in a way that avoids naming collisions.
