### PR TITLE
Prompt for multiple triton networks when creating triton node and manager

### DIFF
--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -291,16 +291,30 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 		return err
 	}
 
+	networks, err := tritonNetworkClient.List(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
 	// Triton Network Names
 	if viper.IsSet("triton_network_names") {
 		cfg.TritonNetworkNames = viper.GetStringSlice("triton_network_names")
-	} else {
-		networks, err := tritonNetworkClient.List(context.Background(), nil)
-		if err != nil {
-			return err
+
+		// Verify triton network names
+		validNetworksMap := map[string]struct{}{}
+		validNetworksSlice := []string{}
+		for _, validNetwork := range networks {
+			validNetworksMap[validNetwork.Name] = struct{}{}
+			validNetworksSlice = append(validNetworksSlice, validNetwork.Name)
 		}
 
-		prompt := promptui.Select{
+		for _, network := range cfg.TritonNetworkNames {
+			if _, ok := validNetworksMap[network]; !ok {
+				return fmt.Errorf("Invalid Triton Network '%s', must be one of the following: %s", network, strings.Join(validNetworksSlice, ", "))
+			}
+		}
+	} else {
+		networkPrompt := promptui.Select{
 			Label: "Triton Networks to attach",
 			Items: networks,
 			Templates: &promptui.SelectTemplates{
@@ -311,12 +325,49 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 			},
 		}
 
-		i, _, err := prompt.Run()
-		if err != nil {
-			return err
+		continueOptions := []struct {
+			Name  string
+			Value bool
+		}{
+			{"Yes", true},
+			{"No", false},
 		}
 
-		cfg.TritonNetworkNames = []string{networks[i].Name}
+		continuePrompt := promptui.Select{
+			Label: "Attach another?",
+			Items: continueOptions,
+			Templates: &promptui.SelectTemplates{
+				Label:    "{{ . }}?",
+				Active:   fmt.Sprintf("%s {{ .Name | underline }}", promptui.IconSelect),
+				Inactive: "  {{.Name}}",
+				Selected: "  Attach another? {{.Name}}",
+			},
+		}
+
+		networksChosen := []string{}
+		shouldPrompt := true
+		for shouldPrompt {
+			// Network Prompt
+			i, _, err := networkPrompt.Run()
+			if err != nil {
+				return err
+			}
+			networksChosen = append(networksChosen, networks[i].Name)
+
+			// Remove the chosen network from the list of choices
+			networkChoices := networkPrompt.Items.([]*network.Network)
+			remainingChoices := append(networkChoices[:i], networkChoices[i+1:]...)
+			networkPrompt.Items = remainingChoices
+
+			// Continue Prompt
+			i, _, err = continuePrompt.Run()
+			if err != nil {
+				return err
+			}
+			shouldPrompt = continueOptions[i].Value
+		}
+
+		cfg.TritonNetworkNames = networksChosen
 	}
 
 	if viper.IsSet("triton_image_name") && viper.IsSet("triton_image_version") {

--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -357,14 +357,18 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 			// Remove the chosen network from the list of choices
 			networkChoices := networkPrompt.Items.([]*network.Network)
 			remainingChoices := append(networkChoices[:i], networkChoices[i+1:]...)
-			networkPrompt.Items = remainingChoices
 
-			// Continue Prompt
-			i, _, err = continuePrompt.Run()
-			if err != nil {
-				return err
+			if len(remainingChoices) == 0 {
+				shouldPrompt = false
+			} else {
+				networkPrompt.Items = remainingChoices
+				// Continue Prompt
+				i, _, err = continuePrompt.Run()
+				if err != nil {
+					return err
+				}
+				shouldPrompt = continueOptions[i].Value
 			}
-			shouldPrompt = continueOptions[i].Value
 		}
 
 		cfg.TritonNetworkNames = networksChosen

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -147,14 +147,19 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 			// Remove the chosen network from the list of choices
 			networkChoices := networkPrompt.Items.([]*network.Network)
 			remainingChoices := append(networkChoices[:i], networkChoices[i+1:]...)
-			networkPrompt.Items = remainingChoices
 
-			// Continue Prompt
-			i, _, err = continuePrompt.Run()
-			if err != nil {
-				return err
+			if len(remainingChoices) == 0 {
+				shouldPrompt = false
+			} else {
+				networkPrompt.Items = remainingChoices
+
+				// Continue Prompt
+				i, _, err = continuePrompt.Run()
+				if err != nil {
+					return err
+				}
+				shouldPrompt = continueOptions[i].Value
 			}
-			shouldPrompt = continueOptions[i].Value
 		}
 
 		cfg.TritonNetworkNames = networksChosen


### PR DESCRIPTION
This allows the user to enter multiple triton networks when creating a node or manager. After selecting a triton network, triton-kubernetes will ask the user if they want to attach another. If the user chooses 'Yes', triton-kubernetes will prompt them for another triton network and ask them again if they would like to attach another. This process continues until the user chooses 'No'.

When the user chooses to add another network, the network choices will exclude networks that have already been selected.