### PR TITLE
Prompt for nodes after creating a cluster

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,10 +13,10 @@ import (
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:       "get [manager]",
+	Use:       "get [manager or cluster]",
 	Short:     "Display resource information",
 	Long:      `Get allows you to get cluster manager details.`,
-	ValidArgs: []string{"manager"},
+	ValidArgs: []string{"manager", "cluster"},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			return errors.New(`"triton-kubernetes get" requires one argument`)
@@ -45,6 +45,13 @@ func getCmdFunc(cmd *cobra.Command, args []string) {
 	case "manager":
 		fmt.Println("get manager called")
 		err := get.GetManager(remoteBackend)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	case "cluster":
+		fmt.Println("get cluster called")
+		err := get.GetCluster(remoteBackend)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/create/node.go
+++ b/create/node.go
@@ -126,6 +126,16 @@ func NewNode(remoteBackend backend.Backend) error {
 		selectedClusterKey = clusters[value]
 	}
 
+	err = newNode(selectedClusterManager, selectedClusterKey, remoteBackend, state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Actually creates the new node
+func newNode(selectedClusterManager, selectedClusterKey string, remoteBackend backend.Backend, state state.State) error {
 	// Determine which cloud the selected cluster is in and call the appropriate newNode func
 	parts := strings.Split(selectedClusterKey, "_")
 	if len(parts) < 3 {
@@ -133,6 +143,7 @@ func NewNode(remoteBackend backend.Backend) error {
 		return fmt.Errorf("Could not determine cloud provider for cluster '%s'", selectedClusterKey)
 	}
 
+	var err error
 	switch parts[1] {
 	case "triton":
 		err = newTritonNode(selectedClusterManager, selectedClusterKey, remoteBackend, state)
@@ -145,11 +156,9 @@ func NewNode(remoteBackend backend.Backend) error {
 	default:
 		return fmt.Errorf("Unsupported cloud provider '%s', cannot create node", parts[0])
 	}
-
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/create/node.go
+++ b/create/node.go
@@ -3,6 +3,7 @@ package create
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -106,6 +107,7 @@ func NewNode(remoteBackend backend.Backend) error {
 		for name := range clusters {
 			clusterNames = append(clusterNames, name)
 		}
+		sort.Strings(clusterNames)
 		prompt := promptui.Select{
 			Label: "Cluster to deploy node to",
 			Items: clusterNames,

--- a/destroy/cluster.go
+++ b/destroy/cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 
 	"github.com/joyent/triton-kubernetes/backend"
 	"github.com/joyent/triton-kubernetes/shell"
@@ -82,6 +83,7 @@ func DeleteCluster(remoteBackend backend.Backend) error {
 		for name := range clusters {
 			clusterNames = append(clusterNames, name)
 		}
+		sort.Strings(clusterNames)
 		prompt := promptui.Select{
 			Label: "Cluster to delete",
 			Items: clusterNames,

--- a/destroy/manager.go
+++ b/destroy/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 
 	"github.com/joyent/triton-kubernetes/backend"
 	"github.com/joyent/triton-kubernetes/shell"
@@ -26,6 +27,7 @@ func DeleteManager(remoteBackend backend.Backend) error {
 	if viper.IsSet("cluster_manager") {
 		selectedClusterManager = viper.GetString("cluster_manager")
 	} else {
+		sort.Strings(clusterManagers)
 		prompt := promptui.Select{
 			Label: "Cluster Manager",
 			Items: clusterManagers,

--- a/destroy/node.go
+++ b/destroy/node.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 
 	"github.com/joyent/triton-kubernetes/backend"
 	"github.com/joyent/triton-kubernetes/shell"
@@ -121,6 +122,7 @@ func DeleteNode(remoteBackend backend.Backend) error {
 		for name := range nodes {
 			nodeNames = append(nodeNames, name)
 		}
+		sort.Strings(nodeNames)
 		prompt := promptui.Select{
 			Label: "Node to delete",
 			Items: nodeNames,

--- a/get/cluster.go
+++ b/get/cluster.go
@@ -1,0 +1,135 @@
+package get
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+
+	"github.com/joyent/triton-kubernetes/backend"
+	"github.com/joyent/triton-kubernetes/shell"
+
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/viper"
+)
+
+func GetCluster(remoteBackend backend.Backend) error {
+	clusterManagers, err := remoteBackend.States()
+	if err != nil {
+		return err
+	}
+
+	if len(clusterManagers) == 0 {
+		return fmt.Errorf("No cluster managers.")
+	}
+
+	selectedClusterManager := ""
+	if viper.IsSet("cluster_manager") {
+		selectedClusterManager = viper.GetString("cluster_manager")
+	} else {
+		prompt := promptui.Select{
+			Label: "Cluster Manager",
+			Items: clusterManagers,
+		}
+
+		_, value, err := prompt.Run()
+		if err != nil {
+			return err
+		}
+
+		selectedClusterManager = value
+	}
+
+	// Verify selected cluster manager exists
+	found := false
+	for _, clusterManager := range clusterManagers {
+		if selectedClusterManager == clusterManager {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("Selected cluster manager '%s' does not exist.", selectedClusterManager)
+	}
+
+	state, err := remoteBackend.State(selectedClusterManager)
+	if err != nil {
+		return err
+	}
+
+	// Get existing clusters
+	clusters, err := state.Clusters()
+	if err != nil {
+		return err
+	}
+
+	if len(clusters) == 0 {
+		return fmt.Errorf("No clusters.")
+	}
+
+	selectedClusterKey := ""
+	if viper.IsSet("cluster_name") {
+		clusterName := viper.GetString("cluster_name")
+		clusterKey, ok := clusters[clusterName]
+		if !ok {
+			return fmt.Errorf("A cluster named '%s', does not exist.", clusterName)
+		}
+
+		selectedClusterKey = clusterKey
+	} else {
+		clusterNames := make([]string, 0, len(clusters))
+		for name := range clusters {
+			clusterNames = append(clusterNames, name)
+		}
+		sort.Strings(clusterNames)
+		prompt := promptui.Select{
+			Label: "Cluster to view",
+			Items: clusterNames,
+			Templates: &promptui.SelectTemplates{
+				Label:    "{{ . }}?",
+				Active:   fmt.Sprintf("%s {{ . | underline }}", promptui.IconSelect),
+				Inactive: " {{ . }}",
+				Selected: fmt.Sprintf(`{{ "%s" | green }} {{ "Cluster:" | bold}} {{ . }}`, promptui.IconGood),
+			},
+		}
+
+		_, value, err := prompt.Run()
+		if err != nil {
+			return err
+		}
+		selectedClusterKey = clusters[value]
+	}
+
+	// Create a temporary directory
+	tempDir, err := ioutil.TempDir("", "triton-kubernetes-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Save the terraform config to the temporary directory
+	jsonPath := fmt.Sprintf("%s/%s", tempDir, "main.tf.json")
+	err = ioutil.WriteFile(jsonPath, state.Bytes(), 0644)
+	if err != nil {
+		return err
+	}
+
+	// Use temporary directory as working directory
+	shellOptions := shell.ShellOptions{
+		WorkingDir: tempDir,
+	}
+
+	// Run terraform init
+	err = shell.RunShellCommand(&shellOptions, "terraform", "init", "-force-copy")
+	if err != nil {
+		return err
+	}
+
+	// Run terraform output
+	err = shell.RunShellCommand(&shellOptions, "terraform", "output", "-module", selectedClusterKey)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
The main change here is that the user is asked if they want to create nodes for the cluster they created. All this is really doing is calling `NewNode` at the end of the cluster process and setting the cluster_name config variable to the newly created cluster. 

Other minor changes:
* Manager, cluster, node names are alphabetized in the prompt select lists
* `get cluster` command has been implemented