### PR TITLE
In HA mode, move gcm and mysql nodes into a private network, specified by the user

### DIFF
--- a/create/cluster.go
+++ b/create/cluster.go
@@ -285,7 +285,7 @@ func NewCluster(remoteBackend backend.Backend) error {
 func getBaseClusterTerraformConfig(terraformModulePath string) (baseClusterTerraformConfig, error) {
 	nonInteractiveMode := viper.GetBool("non-interactive")
 	cfg := baseClusterTerraformConfig{
-		RancherAPIURL: "http://${element(module.cluster-manager.masters, 0)}:8080",
+		RancherAPIURL: "${module.cluster-manager.rancher_url}",
 
 		// Set node counts to 0 since we manage nodes individually in triton-kubernetes cli
 		EtcdNodeCount:          "0",

--- a/create/node.go
+++ b/create/node.go
@@ -191,7 +191,7 @@ func newNode(selectedClusterManager, selectedClusterKey string, remoteBackend ba
 
 func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, currentState state.State) (baseNodeTerraformConfig, error) {
 	cfg := baseNodeTerraformConfig{
-		RancherAPIURL:        "http://${element(module.cluster-manager.masters, 0)}:8080",
+		RancherAPIURL:        "${module.cluster-manager.rancher_url}",
 		RancherEnvironmentID: fmt.Sprintf("${module.%s.rancher_environment_id}", selectedCluster),
 
 		// Grab registry variables from cluster config

--- a/terraform/modules/triton-rancher/files/install_nginx.sh
+++ b/terraform/modules/triton-rancher/files/install_nginx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Installing nginx
+sudo apt-get update -y
+sudo apt-get install nginx -y
+sudo ufw allow 'Nginx Full'
+
+# Removing nginx default config
+sudo rm -f /etc/nginx/sites-enabled/default
+
+# Adding nginx rancher_proxy config
+NGINX_CONFIG="${nginx_config}"
+sudo echo "$NGINX_CONFIG" > /etc/nginx/sites-available/rancher_proxy
+sudo ln -s /etc/nginx/sites-available/rancher_proxy /etc/nginx/sites-enabled/rancher_proxy
+
+# Restarting nginx to reload config
+sudo service nginx restart

--- a/terraform/modules/triton-rancher/files/rancher_proxy_nginx.conf
+++ b/terraform/modules/triton-rancher/files/rancher_proxy_nginx.conf
@@ -1,0 +1,28 @@
+# Nginx configuration for HTTP proxy
+
+upstream rancher_masters {
+${upstream_config}
+}
+
+map $http_upgrade $connection_upgrade {
+    default Upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name _;
+
+    location / {
+        proxy_pass http://rancher_masters;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/terraform/modules/triton-rancher/files/setup_rancher.sh.tpl
+++ b/terraform/modules/triton-rancher/files/setup_rancher.sh.tpl
@@ -13,7 +13,7 @@ done
 curl -X PUT \
 	-H 'Accept: application/json' \
 	-H 'Content-Type: application/json' \
-	-d '{"id":"api.host","type":"activeSetting","baseType":"setting","name":"api.host","activeValue":null,"inDb":false,"source":null,"value":"http://${primary_ip}:8080"}' \
+	-d '{"id":"api.host","type":"activeSetting","baseType":"setting","name":"api.host","activeValue":null,"inDb":false,"source":null,"value":"${host_registration_url}"}' \
 	'${rancher_host}/v2-beta/settings/api.host'
 
 # Update default registry to private registry if requested

--- a/terraform/modules/triton-rancher/main.tf
+++ b/terraform/modules/triton-rancher/main.tf
@@ -5,9 +5,23 @@ provider "triton" {
   url          = "${var.triton_url}"
 }
 
+locals {
+  rancher_url = "${var.ha ? format("http://%s-proxy.svc.%s.us-east-1.triton.zone", lower(var.name), data.triton_account.main.id) : format("http://%s:8080", element(triton_machine.rancher_master.*.primaryip, 0))}"
+}
+
+data "triton_account" "main" {}
+
 data "triton_network" "networks" {
   count = "${length(var.triton_network_names)}"
   name  = "${element(var.triton_network_names, count.index)}"
+}
+
+data "triton_network" "public" {
+  name = "Joyent-SDC-Public"
+}
+
+data "triton_network" "private" {
+  name = "Joyent-SDC-Private"
 }
 
 data "triton_image" "image" {
@@ -31,6 +45,66 @@ data "template_file" "install_rancher_mysqldb" {
   }
 }
 
+data "template_file" "install_nginx" {
+  template = "${file("${path.module}/files/install_nginx.sh")}"
+
+  vars {
+    nginx_config = "${replace(data.template_file.rancher_proxy_nginx_conf.rendered, "$", "\\$")}"
+  }
+}
+
+data "template_file" "rancher_proxy_nginx_conf" {
+  template = "${file("${path.module}/files/rancher_proxy_nginx.conf")}"
+  vars {
+    upstream_config = "${join("\n", formatlist("    server %s:8080;", triton_machine.rancher_master.*.primaryip))}"
+  }
+}
+
+# Temporarily requiring the user to provide the private network with NAT enabled since
+# creating one through terraform results in a network that can't be deleted.
+# This is an issue with Triton: https://smartos.org/bugview/NAPI-258
+data "triton_network" "gcm_private_network" {
+  name = "${var.gcm_private_network_name}"
+}
+
+# Creating the nginx proxy for the gcm nodes
+resource "triton_machine" "rancher_proxy" {
+  # Only make rancher_proxy when HA is configured
+  count = "${var.ha ? 2 : 0}"
+  # Should package/image be hardcoded to a specific machine package?
+  package = "${var.master_triton_machine_package}"
+  image = "${data.triton_image.image.id}"
+  name = "${var.name}-proxy-${count.index + 1}"
+
+  # Attach to private network and public network
+  networks = ["${data.triton_network.public.id}", "${data.triton_network.gcm_private_network.id}"]
+
+  user_script = "${data.template_file.install_nginx.rendered}"
+
+  cns = {
+    services = ["${var.name}-proxy"]
+  }
+
+  affinity = ["role!=~gcm_proxy"]
+
+  tags = {
+    role = "gcm_proxy"
+  }
+}
+
+# Creating the ssh bastion host for the gcm private network
+resource "triton_machine" "rancher_ssh_bastion" {
+  count = "${var.ha}"
+
+  # Should package/image be hardcoded to a specific machine package?
+  package = "${var.master_triton_machine_package}"
+  image = "${data.triton_image.image.id}"
+  name = "${var.name}-ssh"
+
+  # Attach to private network and public network
+  networks = ["${data.triton_network.public.id}", "${data.triton_network.gcm_private_network.id}"]
+}
+
 resource "triton_machine" "rancher_mysqldb" {
   count = "${var.ha}"
 
@@ -38,7 +112,7 @@ resource "triton_machine" "rancher_mysqldb" {
   image   = "${data.triton_image.mysql_image.id}"
   name    = "${var.name}-mysqldb"
 
-  networks = ["${data.triton_network.networks.*.id}"]
+  networks = ["${data.triton_network.gcm_private_network.id}"]
 
   user_script = "${data.template_file.install_rancher_mysqldb.rendered}"
 }
@@ -68,7 +142,11 @@ resource "triton_machine" "rancher_master" {
 
   user_script = "${data.template_file.install_docker.rendered}"
 
-  networks = ["${data.triton_network.networks.*.id}"]
+  # If HA is enabled, this attaches rancher masters to gcm_private_network
+  # Otherwise, the rancher master is attached to triton_network.networks
+  # join and split are used because terraform conditionals do not support list or maps
+  # https://github.com/hashicorp/terraform/issues/12453
+  networks = ["${split(",", var.ha ? data.triton_network.gcm_private_network.id : join(",", data.triton_network.networks.*.id))}"]
 
   cns = {
     services = ["${var.name}"]
@@ -111,6 +189,7 @@ resource "null_resource" "install_rancher_master" {
   connection {
     type        = "ssh"
     user        = "${var.triton_ssh_user}"
+    bastion_host = "${element(coalescelist(triton_machine.rancher_ssh_bastion.*.primaryip, list("")), 0)}"
     host        = "${element(triton_machine.rancher_master.*.primaryip, count.index)}"
     private_key = "${file(var.triton_key_path)}"
   }
@@ -128,7 +207,7 @@ data "template_file" "setup_rancher_k8s" {
   vars {
     name         = "${var.name}"
     rancher_host = "http://127.0.0.1:8080"
-    primary_ip   = "${element(triton_machine.rancher_master.*.primaryip, 0)}"
+    host_registration_url = "${local.rancher_url}"
 
     rancher_registry = "${var.rancher_registry}"
   }
@@ -147,6 +226,7 @@ resource "null_resource" "setup_rancher_k8s" {
   connection {
     type        = "ssh"
     user        = "${var.triton_ssh_user}"
+    bastion_host = "${element(coalescelist(triton_machine.rancher_ssh_bastion.*.primaryip, list("")), 0)}"
     host        = "${element(triton_machine.rancher_master.*.primaryip, 0)}"
     private_key = "${file(var.triton_key_path)}"
   }

--- a/terraform/modules/triton-rancher/outputs.tf
+++ b/terraform/modules/triton-rancher/outputs.tf
@@ -1,3 +1,12 @@
 output "masters" {
   value = "${triton_machine.rancher_master.*.primaryip}"
 }
+
+output "rancher_url" {
+  depends_on = ["triton_machine.rancher_proxy"]
+  value = "${local.rancher_url}"
+}
+
+output "ssh_bastion_ip" {
+  value = "${element(coalescelist(triton_machine.rancher_ssh_bastion.*.primaryip, list("")), 0)}"
+}

--- a/terraform/modules/triton-rancher/variables.tf
+++ b/terraform/modules/triton-rancher/variables.tf
@@ -65,6 +65,11 @@ variable "gcm_node_count" {
   description = "Number of Global Cluster Managers to cluster."
 }
 
+variable "gcm_private_network_name" {
+  default     = "Joyent-SDC-Private"
+  description = "Should Rancher be deployed in HA, this network will contain the mysqldb, Rancher master, nginx proxy, and bastion nodes. In non-HA mode, this will be ignored."
+}
+
 variable "mysqldb_triton_machine_package" {
   default     = ""
   description = "The Triton machine package to use for the Rancher mysqldb node. Defaults to master_triton_machine_package."


### PR DESCRIPTION
- Add nginx proxy instances with the same cns service tags
- Added rancher_url output variable which is set to the triton cns url for HA mode
- Added ssh_bastion_ip output variable
- During rancher_setup.sh, registration host url is set to triton cns url