### PR TITLE
Do not prompt for triton networks when creating rancher with HA

### DIFF
--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -458,7 +458,11 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 	}
 
 	// Triton Network Names
-	if viper.IsSet("triton_network_names") {
+	if cfg.HA {
+		// Since cluster manager nodes are in a private network,
+		// just set the network names to the private network.
+		cfg.TritonNetworkNames = []string{cfg.GCMPrivateNetworkName}
+	} else if viper.IsSet("triton_network_names") {
 		cfg.TritonNetworkNames = viper.GetStringSlice("triton_network_names")
 
 		// Verify triton network names


### PR DESCRIPTION
For HA, since the gcm nodes are hidden behind a private network, we don't need to prompt the user for the network to attach to the gcm nodes.
