### PR TITLE
Automated Build and Release with Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/terraform*
 */terraform.tfstate*
 terraform/.terraform*
 .terraform*
+build/
 
 triton-kubernetes
 main.tf.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+go:
+- 1.9.x
+before_script:
+- curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+script:
+- dep ensure
+- go test ./...
+before_deploy:
+- sudo apt-get install ruby ruby-dev build-essential rpm
+- gem install --no-ri --no-rdoc fpm
+- make build VERSION=`echo ${TRAVIS_TAG//v/}`
+deploy:
+  provider: releases
+  api-key:
+    secure: fskhix8WkS21by2KzyOvxh9sKmANxZifcxZRdHXayoLaqqk5XMFSo5EYdEW+ypzKrBix6HxzUuSOBVlhSgN6DdUXpWnzoYbJYZ7owtWuaSAur47DWhc4JTkFH0anT6gFUHwPd5N01ysD0Yahn8CRQzW33ChE8qOdIw48I2/S63Q10ZsO1obkFUhluvR/CsmmICh5rCCUlcBv6RDIZYgStGErQMTRQnDLuB8i+g7bL8tGL1WbSUtXDKmVohpw6Kw4Bd/gcEfZ8x+q2XDaKIJC6+N6nNmi9ProRP7DlIUH9mnIqv7J7h0b0izuZJh7um40TecuxIofzYWNRvSzBj2gdoorVaqmzKYpGtmn8eNchWMSsVWZdnFs21zb9fwnsOAUmiNbsUFOccLrPyK2MoNW4W1nS9d20bXEAs9M6mzz3lciFAe0Lo6Xe/KrErRjXuWULUSaVLcFNfTXrrDA06zRjGaurgqMi63zf/w3dmhuncDvw8hPRU9/tZBjp31FB05Kqfxn4ce35zc68FfO5L7oUa9bMz5VPU0NRLh3pl5XTpHOK1piiXinIWAy51S8xwtBCO5i/O9VBbo9pNzrlheHzQd0eC3t8SE1LNafvUy2hUSfjm0Z1+cXBQN8DsPPlqzoiODH+iq5vinTfPrqsrZMokWB8MIR/xTegcwXRNIS8Xw=
+  file_glob: true
+  file: build/*
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: $TRAVIS_TAG =~ ^v[0-9]+.[0-9]+.[0-9]+$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+VERSION=0.0.1
+PATH_BUILD=build
+FILE_COMMAND=triton-kubernetes
+
+OSX_BUILD_PATH=$(PATH_BUILD)/mac_osx
+OSX_ARCHIVE_PATH=$(OSX_BUILD_PATH)/triton-kubernetes.zip
+OSX_BINARY_PATH=$(OSX_BUILD_PATH)/triton-kubernetes
+OSX_CHECKSUM_PATH=$(OSX_BUILD_PATH)/sha256_checksum
+
+LINUX_BUILD_PATH=$(PATH_BUILD)/linux
+
+clean:
+	@rm -rf ./build
+
+build: build-osx build-linux
+
+build-osx: clean
+	@echo "Building OSX..."
+	@mkdir -p $(OSX_BUILD_PATH)
+	@GOOS=darwin GOARCH=amd64 go build -o $(OSX_BUILD_PATH)/triton-kubernetes
+	@zip --junk-paths $(OSX_ARCHIVE_PATH) $(OSX_BINARY_PATH)
+	@shasum -a 256 $(OSX_ARCHIVE_PATH) > $(OSX_CHECKSUM_PATH)
+
+build-linux: clean
+	@echo "Building Linux..."
+	@mkdir -p $(LINUX_BUILD_PATH)
+	@GOOS=linux GOARCH=amd64 go build -o $(LINUX_BUILD_PATH)/triton-kubernetes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.0.1
+VERSION=0.0.0
 BUILD_PATH=build
 FILE_COMMAND=triton-kubernetes
 

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ OSX_BINARY_PATH=$(BUILD_PATH)/triton-kubernetes_osx-amd64
 LINUX_BINARY_PATH=$(BUILD_PATH)/triton-kubernetes_linux-amd64
 
 RPM_PATH=$(BUILD_PATH)/triton-kubernetes_$(VERSION)_linux-amd64.rpm
+DEB_PATH=$(BUILD_PATH)/triton-kubernetes_$(VERSION)_linux-amd64.deb
 
 clean:
 	@rm -rf ./build
 
-build: build-osx build-linux build-rpm
+build: clean build-osx build-linux build-rpm build-deb
 	@echo "Generating checksums..."
 	@cd build; shasum -a 256 * > sha256-checksums.txt
 
@@ -31,3 +32,9 @@ build-rpm: build-linux
 	@echo "Building RPM..."
 	@fpm --input-type dir --output-type rpm --name triton-kubernetes -v $(VERSION) --prefix /opt/triton-kubernetes --package $(RPM_PATH) $(LINUX_BINARY_PATH)
 
+build-deb: build-linux
+	@echo "Building DEB..."
+# 	fpm fails with a tar error when building the DEB package on OSX 10.10.
+# 	Current workaround is to modify PATH so that fpm uses gnu-tar instead of the regular tar command.
+#	Issue URL: https://github.com/jordansissel/fpm/issues/882
+	@PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$$PATH" fpm --input-type dir --output-type deb --name triton-kubernetes -v $(VERSION) --prefix /opt/triton-kubernetes --package $(DEB_PATH) $(LINUX_BINARY_PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,26 @@
 VERSION=0.0.1
-PATH_BUILD=build
+BUILD_PATH=build
 FILE_COMMAND=triton-kubernetes
 
-OSX_BUILD_PATH=$(PATH_BUILD)/mac_osx
-OSX_ARCHIVE_PATH=$(OSX_BUILD_PATH)/triton-kubernetes.zip
-OSX_BINARY_PATH=$(OSX_BUILD_PATH)/triton-kubernetes
-OSX_CHECKSUM_PATH=$(OSX_BUILD_PATH)/sha256_checksum
+OSX_ARCHIVE_PATH=$(BUILD_PATH)/triton-kubernetes_osx-amd64.zip
+OSX_BINARY_PATH=$(BUILD_PATH)/triton-kubernetes_osx-amd64
 
-LINUX_BUILD_PATH=$(PATH_BUILD)/linux
+LINUX_BINARY_PATH=$(BUILD_PATH)/triton-kubernetes_linux-amd64
 
 clean:
 	@rm -rf ./build
 
 build: build-osx build-linux
+	@echo "Generating checksums..."
+	@cd build; shasum -a 256 * > sha256-checksums.txt
 
 build-osx: clean
 	@echo "Building OSX..."
-	@mkdir -p $(OSX_BUILD_PATH)
-	@GOOS=darwin GOARCH=amd64 go build -o $(OSX_BUILD_PATH)/triton-kubernetes
+	@mkdir -p $(BUILD_PATH)
+	@GOOS=darwin GOARCH=amd64 go build -o $(OSX_BINARY_PATH)
 	@zip --junk-paths $(OSX_ARCHIVE_PATH) $(OSX_BINARY_PATH)
-	@shasum -a 256 $(OSX_ARCHIVE_PATH) > $(OSX_CHECKSUM_PATH)
 
 build-linux: clean
 	@echo "Building Linux..."
-	@mkdir -p $(LINUX_BUILD_PATH)
-	@GOOS=linux GOARCH=amd64 go build -o $(LINUX_BUILD_PATH)/triton-kubernetes
+	@mkdir -p $(BUILD_PATH)
+	@GOOS=linux GOARCH=amd64 go build -o $(LINUX_BINARY_PATH)

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ build-rpm: build-linux
 		--chdir $(RPM_TMP_DIR) \
 		--input-type dir \
 		--output-type rpm \
+		--depends jq \
 		--rpm-os linux \
 		--name triton-kubernetes \
 		--version $(VERSION) \
@@ -65,6 +66,7 @@ build-deb: build-linux
 		--chdir $(DEB_TMP_DIR) \
 		--input-type dir \
 		--output-type deb \
+		--depends jq \
 		--name triton-kubernetes \
 		--version $(VERSION) \
 		--prefix $(DEB_INSTALL_DIR) \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ LINUX_BINARY_PATH=$(BUILD_PATH)/$(LINUX_BINARY_FILE_NAME)
 
 RPM_FILE_NAME=triton-kubernetes_$(VERSION)_linux-amd64.rpm
 RPM_PATH=$(BUILD_PATH)/$(RPM_FILE_NAME)
+RPM_INSTALL_DIR=/usr/bin
+RPM_TMP_DIR=$(BUILD_PATH)/build-rpm-tmp
 
 DEB_FILE_NAME=triton-kubernetes_$(VERSION)_linux-amd64.deb
 DEB_PATH=$(BUILD_PATH)/$(DEB_FILE_NAME)
@@ -36,7 +38,20 @@ build-linux: clean
 
 build-rpm: build-linux
 	@echo "Building RPM..."
-	@fpm --input-type dir --output-type rpm --name triton-kubernetes --version $(VERSION) --prefix /opt/triton-kubernetes --package $(RPM_PATH) $(LINUX_BINARY_PATH)
+#	Copying and renaming the linux binary to just 'triton-kubernetes'. Making a temp directory to avoid potential naming conflicts.
+	@mkdir -p $(RPM_TMP_DIR)
+	@cp $(LINUX_BINARY_PATH) $(RPM_TMP_DIR)/triton-kubernetes
+	@fpm \
+		--chdir $(RPM_TMP_DIR) \
+		--input-type dir \
+		--output-type rpm \
+		--rpm-os linux \
+		--name triton-kubernetes \
+		--version $(VERSION) \
+		--prefix $(RPM_INSTALL_DIR) \
+		--package $(RPM_PATH) triton-kubernetes
+#	Cleaning up the tmp directory
+	@rm -rf $(RPM_TMP_DIR)
 
 build-deb: build-linux
 	@echo "Building DEB..."

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ OSX_BINARY_PATH=$(BUILD_PATH)/triton-kubernetes_osx-amd64
 
 LINUX_BINARY_PATH=$(BUILD_PATH)/triton-kubernetes_linux-amd64
 
+RPM_PATH=$(BUILD_PATH)/triton-kubernetes_$(VERSION)_linux-amd64.rpm
+
 clean:
 	@rm -rf ./build
 
-build: build-osx build-linux
+build: build-osx build-linux build-rpm
 	@echo "Generating checksums..."
 	@cd build; shasum -a 256 * > sha256-checksums.txt
 
@@ -24,3 +26,8 @@ build-linux: clean
 	@echo "Building Linux..."
 	@mkdir -p $(BUILD_PATH)
 	@GOOS=linux GOARCH=amd64 go build -o $(LINUX_BINARY_PATH)
+
+build-rpm: build-linux
+	@echo "Building RPM..."
+	@fpm --input-type dir --output-type rpm --name triton-kubernetes -v $(VERSION) --prefix /opt/triton-kubernetes --package $(RPM_PATH) $(LINUX_BINARY_PATH)
+


### PR DESCRIPTION
This has the .travis.yml and Makefile setup. I've included below a write-up of what we need to get done to set up automated builds and releases.

## Setting Up Travis CI

In order for Travis CI to start building and releasing, Travis CI must be configured for the triton-kubernetes repo. To let TravisCI upload Github releases, an encrypted Github API Key must be provided in the .travis.yml file.
1. Create a Github API Key and save the API Key locally (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)
2. Install the travis cli https://github.com/travis-ci/travis.rb#installation
3. Run travis encrypt <your-github-api-key-here>
4. Enter the encrypted text in the .travis.yml file at deploy.api-key.secure

## The Release Process

The release process involves two steps: publishing binaries to Github releases and adding the new release to the homebrew registry.

### Creating a Release

To create a release, you just need to create and push a git tag with the proper name (e.g. v0.0.1). Once the tag is set, Travis CI will begin the release process.
1. Using the git cli, checkout the commit you would like to release
2. Run `git tag v0.0.0`, where `v0.0.0` is the desired version number
3. Run `git push origin v0.0.0` 
4. TravisCI will begin building the binaries using the commit that was tagged.
4. After TravisCI is done, check the Github releases page to verify that the binaries have been uploaded.

### Creating a Release Manually

To build the binaries locally, you will need to install the following on your machine:
* rpmbuild (For OS X, you can run `brew install rpm`)
* [fpm](https://github.com/jordansissel/fpm)

Then run `make build VERSION=0.0.0` where 0.0.0 is replaced with the desired version number.

### Updating the homebrew registry

The github repository at: https://github.com/Homebrew/homebrew-core serves as the homebrew registry. To submit a pull request to that repo:
1. Fork the homebrew-core repository
2. In the Formula folder, add a brew formula for triton-kubernetes (triton-kubernetes.rb). Requires:
    * SHA256 checksum of the .tar.gz file from the Github release (use shasum command)
    * new version number
    * See example at https://github.com/cg50x/homebrew-test/blob/master/Formula/triton-kubernetes.rb
3. Submit a pull request to the homebrew-core repository. Once it is merged, you can verify that it works by running `brew update` and then `brew install triton-kubernetes`.

